### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,8 @@
 name: Code scanning (CodeQL)
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [ready_for_review, opened, reopened, synchronize]

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,7 +2,7 @@ name: Code scanning (CodeQL)
 
 permissions:
   contents: read
-
+  security-events: write
 on:
   pull_request:
     types: [ready_for_review, opened, reopened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/terms-and-conditions/security/code-scanning/3](https://github.com/Informasjonsforvaltning/terms-and-conditions/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions:` block either at the root of the workflow (to apply to all jobs) or on the specific job (`jobs.codeql`) so that the `GITHUB_TOKEN` is limited to the minimum required scopes. For a typical CodeQL analysis that only needs to read the repository contents and possibly security events, `contents: read` plus, optionally, `security-events: write` (for uploading results) are common; however, we must not assume extra scopes beyond the minimum needed for a read-only baseline.

The single best minimally invasive fix here is to add a workflow-level `permissions:` block just after the `name:` line, before the `on:` section. This will apply to all jobs (including `codeql`) that do not override `permissions`. As a conservative least-privilege baseline in line with the recommendation, we can set `contents: read` only, which is equivalent to a read-only repository permission and avoids granting write access. No imports or additional definitions are needed, only a small YAML edit in `.github/workflows/codeql.yaml`.

Concretely:
- Edit `.github/workflows/codeql.yaml`.
- Insert:

  ```yaml
permissions:
  contents: read
  security-events: write
  ```

  after line 1 (`name: Code scanning (CodeQL)`) and before the `on:` block.
- Leave the rest of the workflow unchanged, so existing behavior is preserved except that the inherited broad default permissions are now reduced to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
